### PR TITLE
`coffee` interpreter for `build-browser`

### DIFF
--- a/build-browser
+++ b/build-browser
@@ -1,4 +1,4 @@
-#!/usr/bin/env node node_modules/.bin/ember-script
+#!/usr/bin/env coffee
 fs = require 'fs'
 path = require 'path'
 mkdirp = require 'mkdirp'


### PR DESCRIPTION
The `build-browser` script complains about

```
/usr/bin/env node node_modules/.bin/ember-script: No such file or directory
```

However, I did check that `node_modules/.bin/ember-script` is present, and
was running perfectly.

I reviewed the `build-browser` script, and noticed that it's just plain
coffeescript, nothing `ember-script` specific. So I changed the interpreter
to plain `coffee` (`/usr/bin/env coffee`).

This PR does just that.
