### PR TITLE
Source gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,14 @@
+desc 'Build distribution js files'
+task :dist do
+  puts 'Building js distribution...'
+  `npm install && ./build-browser`
+  puts 'Successfully built epf at dist/'
+end
+
+# bundler tasks
+require 'bundler/gem_tasks'
+
+desc 'Build distribution js files and publish source gem'
+task :publish => [:dist, :release]
+
+task :default => [:dist]

--- a/epf-source.gemspec
+++ b/epf-source.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+require 'json'
+
+package = JSON.parse(File.read('package.json'))
+
+Gem::Specification.new do |gem|
+  gem.name        = 'epf-source'
+  gem.version     = package['version']
+  gem.authors     = ['Gordon L. Hempton']
+  gem.email       = []
+  gem.date        = Time.now.strftime('%Y-%m-%d')
+  gem.summary     = 'Epf source code wrapper'
+  gem.description = 'Epf source code wrapper for ruby libs.'
+  gem.homepage    = 'https://github.com/GroupTalent/epf'
+
+  gem.files       = ['dist/epf.js', 'lib/epf/source.rb']
+
+  gem.license     = 'MIT'
+end

--- a/lib/epf/source.rb
+++ b/lib/epf/source.rb
@@ -1,0 +1,7 @@
+module Epf
+  module Source
+    def self.bundled_path
+      File.expand_path('../../../dist/epf.js', __FILE__)
+    end
+  end
+end


### PR DESCRIPTION
This PR makes a source gem for `epf`.

Details that might need reviewing / approving:
- @ghempton is listed as sole author
- no gem email
- MIT license

Source gem is called `epf-source`. Would have been better to name it with the
`ember-` prefix to be in line of other ember-\* gems out there, but `epf`
itself goes without the `ember-*` prefix, so, well, `epf-source` it is.
