### PR TITLE
Ignore pkg/ files from gem build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+pkg
 
 .DS_Store


### PR DESCRIPTION
This PR just adds `pkg/` to `.gitignore`. They are leftovers from publishing the source gem (`rake publish`).
