### PR TITLE
Removed duplicate require('./session')

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,9 @@
-
 global.Ep = Ember.Namespace.create();
 
 require('./initializer');
 require('./model');
 require('./session');
 require('./serializer');
-require('./session');
 
 require('./local');
 require('./rest');


### PR DESCRIPTION
I removed the duplicate require. I'm assuming `session` comes before `serializer`.
