### PR TITLE
Source map fix

### DIFF
--- a/build-browser
+++ b/build-browser
@@ -16,7 +16,7 @@ jsAst = (require 'commonjs-everywhere').cjsify 'lib/index.js', __dirname,
 codeWithoutAsserts = code.replace(/^(\s)*Ember\.(assert|deprecate|warn|debug)\((.*)\).*$/mg, '')
 
 mkdirp 'dist', ->
-  fs.writeFile 'dist/epf.js', "#{code}\n/*\n//@ sourceMappingURL=eps.js.map\n*/"
+  fs.writeFile 'dist/epf.js', "#{code}\n/*\n//@ sourceMappingURL=epf.js.map\n*/"
   fs.writeFile 'dist/epf.prod.js', codeWithoutAsserts
 
   fs.writeFile 'dist/epf.js.map', map

--- a/epf-source.gemspec
+++ b/epf-source.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.description = 'Epf source code wrapper for ruby libs.'
   gem.homepage    = 'https://github.com/GroupTalent/epf'
 
-  gem.files       = ['dist/epf.js', 'lib/epf/source.rb']
+  gem.files       = ['dist/epf.js', 'dist/epf.js.map', 'lib/epf/source.rb']
 
   gem.license     = 'MIT'
 end

--- a/lib/epf/source.rb
+++ b/lib/epf/source.rb
@@ -3,5 +3,9 @@ module Epf
     def self.bundled_path
       File.expand_path('../../../dist/epf.js', __FILE__)
     end
+
+    def self.bundled_map_path
+      File.expand_path('../../../dist/epf.js.map', __FILE__)
+    end
   end
 end


### PR DESCRIPTION
This PR adds `epf.js.map` to the source gem, and fixes the `build-browser` script: it references `eps.js.map`, which I assume is a typo for `epf.js.map`.

Pending a new source gem release, the corresponding `epf-rails` gem can be updated to use the source map too.
