### PR TITLE
Use Ember.copy() for model.copy()

### DIFF
--- a/lib/model/model.js
+++ b/lib/model/model.js
@@ -183,8 +183,8 @@ Ep.Model = Ember.Object.extend(Ember.Copyable, Ep.ModelMixin, {
     this.eachAttribute(function(name, meta) {
       var left = get(this, name);
       var right = get(dest, name);
-      // TODO: handle non-primitive attributes
-      set(dest, name, left);
+      // Ember.copy shallow copy of the attribute
+      set(dest, name, Ember.copy(left));
     }, this);
     dest.endPropertyChanges();
   }

--- a/test/model/model.em
+++ b/test/model/model.em
@@ -43,6 +43,13 @@ describe 'Ep.Model', ->
       user.session = SessionStub.create()
       expect(user.isDirty).to.be.false
 
+  describe 'copy', ->
+    it 'copies objects in attributes', ->
+      u1 = App.User.create()
+      u1.user = ["firstname", "lastname"]
+      u2 = u1.copy()
+      u1.user = ["john", "doe"]
+      expect(u1.user).not.to.be.eq(u2.user)
 
   it 'can use .find', ->
     class SessionStub


### PR DESCRIPTION
Ember.copy() also correctly copies arrays, objects and such (i.e.
embedded records). Without Ember.copy(), only the references get copied,
and updates on the the original still have an effect on the copy and
vice versa.

This fixes issue #21.
