### PR TITLE
Models with missing embedded keys can now be loaded

### DIFF
--- a/lib/serializer/serializer.js
+++ b/lib/serializer/serializer.js
@@ -290,6 +290,10 @@ Ep.Serializer = Ember.Object.extend({
   },
 
   deserializeEmbeddedHasMany: function(name, model, values, relationship) {
+    // no-op if null
+    if(!values) {
+      values = [];
+    }
     get(model, name).addObjects(values.map(function(data) {
       var type = this.extractEmbeddedType(relationship, data);
       return this.deserializeModel(type, data);

--- a/lib/serializer/serializer.js
+++ b/lib/serializer/serializer.js
@@ -292,7 +292,7 @@ Ep.Serializer = Ember.Object.extend({
   deserializeEmbeddedHasMany: function(name, model, values, relationship) {
     // no-op if null
     if(!values) {
-      values = [];
+      return;
     }
     get(model, name).addObjects(values.map(function(data) {
       var type = this.extractEmbeddedType(relationship, data);

--- a/test/rest/rest.acceptance.em
+++ b/test/rest/rest.acceptance.em
@@ -92,6 +92,14 @@ describe "rest", ->
             expect(user.groups.length).to.eq(1)
             expect(adapter.h).to.eql(['POST:/users', 'POST:/groups', 'PUT:/groups/2'])
 
+    it "doesn't choke when loading a group without a members key", ->
+      adapter.r['GET:/groups'] = groups: [{client_id: null, id: "1", name: "brogrammers", user_id: "1"}]
+
+      session.query("group").then (result) ->
+        expect(adapter.h).to.eql(['GET:/groups'])
+        expect(result.content.length).to.eq(1)
+        expect(result.content[0].name).to.eq("brogrammers")
+        expect(result.content[0].groups).to.be.undefined
 
   describe "managing comments", ->
 


### PR DESCRIPTION
I have a user model which represents various types of users, some have certain embedded relationships that others do not.

This small patch fixes load errors that occur in such a case when models do not have all embedded keys present.
