### PR TITLE
load lazy models only when they have a session

### DIFF
--- a/lib/model/proxies.js
+++ b/lib/model/proxies.js
@@ -128,24 +128,27 @@ Ep.LazyModel = Ep.ModelPromise.extend({
     var session = get(this, 'session');
     var type = get(this, 'type');
     var id = get(this, 'id');
-    set(this, 'isLoading', true);
 
-    Ember.assert("Must be attached to a session.", get(this, 'session'));
-    Ember.assert("Must have an id to load.", id);
+    // The model can happen to not have a session yet
+    if (session) {
+      set(this, 'isLoading', true);
 
-    var promise = this.session.load(type, id);
+      Ember.assert("Must have an id to load.", id);
 
-    if(get(promise, 'isLoaded')) {
-      this.resolve(Ep.unwrap(promise));
-    } else {
-      var proxy = this;
-      promise.then(function(model) {
-        proxy.resolve(model);
-        return model;
-      }, function(err) {
-        proxy.reject(err);
-        return err;
-      });
+      var promise = this.session.load(type, id);
+
+      if(get(promise, 'isLoaded')) {
+        this.resolve(Ep.unwrap(promise));
+      } else {
+        var proxy = this;
+        promise.then(function(model) {
+          proxy.resolve(model);
+          return model;
+        }, function(err) {
+          proxy.reject(err);
+          return err;
+        });
+      }
     }
     return this;
   },


### PR DESCRIPTION
This fix removed lots of errors from my console, and stabilized my app.

It seems that while EPF loads json with sideloaded models, at some point models don't have a session yet but are triggered to load because of observers. Without this fix it just breaks and the lazy model is never resolved. With it, the loading eventually takes place.
