### PR TITLE
Serialize hasmany as ids by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ For now, as epf is in development, follow the development instructions to use ep
 
 ## Getting Started
 
-By default, epf assumes that the backend is a REST api.
+### Your backend
+
+By default, epf assumes that the backend is a REST api which sticks to pretty much the same conventions as ember-data's RESTAdapter needs. There are a few differences however:
+
+* EPF sets a `client_id` in the JSON for every model and expects this to be echoed back by the server. It uses this to keep it's internal idmap up to date.
+* Related keys still need to use _id and _ids (this is different from ember-data 1.0 beta 2)
 
 ### Defining Models
 

--- a/lib/serializer/json_serializer/serialize.js
+++ b/lib/serializer/json_serializer/serialize.js
@@ -231,24 +231,34 @@ Ep.JsonSerializer.reopen({
         key = this.keyForHasMany(name, type),
         serializedHasMany = [],
         includeType = (relationship.options && relationship.options.polymorphic),
-        manyArray, embeddedType;
+        manyArray, embeddedType, id;
 
     // If the has-many is not embedded, there is nothing to do.
     embeddedType = this.embeddedType(type, name);
-    if (embeddedType !== 'always') { return; }
+    if (embeddedType === 'always') {
+      // Get the Ep.ManyArray for the relationship off the model
+      manyArray = get(model, name);
 
-    // Get the Ep.ManyArray for the relationship off the model
-    manyArray = get(model, name);
+      // Build up the array of serialized models
+      manyArray.forEach(function (model) {
+        serializedHasMany.push(this.serialize(model, { includeType: includeType }));
+      }, this);
+    }
+    else {
+      // Get the Ep.ManyArray for the relationship off the model
+      manyArray = get(model, name);
 
-    // Build up the array of serialized models
-    manyArray.forEach(function (model) {
-      serializedHasMany.push(this.serialize(model, { includeType: includeType }));
-    }, this);
+      // Build up the array of serialized models
+      manyArray.forEach(function (model) {
+        id = get(model, 'id');
+        if(id !== undefined) {
+          serializedHasMany.push(this.serializeId(id));
+        }
+      }, this);
+    }
 
     // Set the appropriate property of the serialized JSON to the
     // array of serialized embedded models
     serialized[key] = serializedHasMany;
   }
-  
-
 });

--- a/lib/serializer/json_serializer/serialize.js
+++ b/lib/serializer/json_serializer/serialize.js
@@ -214,11 +214,9 @@ Ep.JsonSerializer.reopen({
   /**
     Adds a has-many relationship to the JSON serialized being built.
 
-    The default REST semantics are to only add a has-many relationship if it
-    is embedded. If the relationship was initially loaded by ID, we assume that
-    that was done as a performance optimization, and that changes to the
-    has-many should be saved as foreign key changes on the child's belongs-to
-    relationship.
+    The default REST semantics are to add a has-many relationship as an array
+    of foreign keys. If you prefer to set the foreign key on the child, you should
+    create a one-way relationship child -> parent.
 
     @param {Object} serialized the JSON being built
     @param {Ep.Model} model the model being serialized


### PR DESCRIPTION
Changed the default serializer behavior to serialize a hasMany to an array of ids by default. This is definitely not a "must-merge" PR but I want to look into the option of at least providing a config option in the relation setup. IMHO is you define a relation to be bi-directional, it's unexpected behavior if the persistence lib assumes your API to be one-directional.

What do you think?
