### PR TITLE
Related key names do not include "_id(s)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ For now, as epf is in development, follow the development instructions to use ep
 By default, epf assumes that the backend is a REST api which sticks to pretty much the same conventions as ember-data's RESTAdapter needs. There are a few differences however:
 
 * EPF sets a `client_id` in the JSON for every model and expects this to be echoed back by the server. It uses this to keep it's internal idmap up to date.
-* Related keys still need to use _id and _ids (this is different from ember-data 1.0 beta 2)
 
 ### Defining Models
 

--- a/lib/rest/rest_serializer.js
+++ b/lib/rest/rest_serializer.js
@@ -50,22 +50,12 @@ Ep.RestSerializer = Ep.JsonSerializer.extend({
 
   keyForBelongsTo: function(name, type) {
     var key = this._super(name, type);
-
-    if (this.embeddedType(type, name)) {
-      return key;
-    }
-
-    return key + "_id";
+    return key;
   },
 
   keyForHasMany: function(name, type) {
     var key = this._super(name, type);
-
-    if (this.embeddedType(type, name)) {
-      return key;
-    }
-
-    return this.singularize(key) + "_ids";
+    return key;
   },
 
   keyForPolymorphicId: function(key) {

--- a/test/rest/rest.acceptance.em
+++ b/test/rest/rest.acceptance.em
@@ -53,7 +53,7 @@ describe "rest", ->
       adapter.r['POST:/users'] = -> users: {client_id: user.clientId, id: "1", name: "wes"}
       adapter.r['POST:/groups'] = (url, type, hash) ->
         expect(hash.data.group.members[0].role).to.eq('chief')
-        return groups: {client_id: group.clientId, id: "2", name: "brogrammers", members: [{client_id: member.clientId, id: "3", role: "chief", post_id: "2", user_id: "1"}], user_id: "1"}
+        return groups: {client_id: group.clientId, id: "2", name: "brogrammers", members: [{client_id: member.clientId, id: "3", role: "chief", post: "2", user: "1"}], user: "1"}
 
       childSession = session.newSession()
       user = childSession.create 'user', name: 'wes'
@@ -84,7 +84,7 @@ describe "rest", ->
           expect(group.members.length).to.eq(0)
           expect(user.groups.length).to.eq(1)
 
-          adapter.r['PUT:/groups/2'] = -> groups: {client_id: group.clientId, id: "2", name: "brogrammers", members: [], user_id: "1"}
+          adapter.r['PUT:/groups/2'] = -> groups: {client_id: group.clientId, id: "2", name: "brogrammers", members: [], user: "1"}
           childSession.flush().then ->
             expect(member.get('isDeleted')).to.be.true
             expect(group.members.length).to.eq(0)
@@ -94,7 +94,7 @@ describe "rest", ->
 
 
     it "doesn't choke when loading a group without a members key", ->
-      adapter.r['GET:/groups'] = groups: [{client_id: null, id: "1", name: "brogrammers", user_id: "1"}]
+      adapter.r['GET:/groups'] = groups: [{client_id: null, id: "1", name: "brogrammers", user: "1"}]
 
       session.query("group").then (result) ->
         expect(adapter.h).to.eql(['GET:/groups'])
@@ -104,7 +104,7 @@ describe "rest", ->
 
 
     it 'adds a member to an existing group', ->
-      adapter.r['GET:/groups/1'] = -> groups: {id: "1", name: "employees", members: [{id: "2", name: "kinz", group_id: "1", user_id: "3"}]}, users: {id: "3", name: "wtf", member_id: "2"}
+      adapter.r['GET:/groups/1'] = -> groups: {id: "1", name: "employees", members: [{id: "2", name: "kinz", group: "1", user: "3"}]}, users: {id: "3", name: "wtf", member: "2"}
 
       session.load("group", 1).then (group) ->
         expect(adapter.h).to.eql(['GET:/groups/1'])
@@ -122,7 +122,7 @@ describe "rest", ->
         expect(childGroup.members.length).to.eq(2)
         expect(group.members.length).to.eq(1)
 
-        adapter.r['PUT:/groups/1'] = -> groups: {id: "1", name: "employees", members: [{id: "2", name: "kinz", group_id: "1"}, {id: 3, client_id: member.clientId, name: "mollie", group_id: "1"}]}
+        adapter.r['PUT:/groups/1'] = -> groups: {id: "1", name: "employees", members: [{id: "2", name: "kinz", group: "1"}, {id: 3, client_id: member.clientId, name: "mollie", group: "1"}]}
         promise = childSession.flush().then ->
           expect(childGroup.members.length).to.eq(2)
           expect(group.members.length).to.eq(2)
@@ -152,7 +152,7 @@ describe "rest", ->
 
 
     it 'creates a new comment within a child session', ->
-      adapter.r['POST:/comments'] = -> comment: {client_id: comment.clientId, id: "3", message: "#2", post_id: "1"}
+      adapter.r['POST:/comments'] = -> comment: {client_id: comment.clientId, id: "3", message: "#2", post: "1"}
 
       post = session.merge @Post.create(id: "1", title: "brogrammer's guide to beer pong")
       session.merge @Comment.create(id: "2", message: "yo", post: post)

--- a/test/rest/rest.one_to_many.em
+++ b/test/rest/rest.one_to_many.em
@@ -29,8 +29,8 @@ describe "rest", ->
 
 
     it 'loads lazily', ->
-      adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comment_ids: [2]}
-      adapter.r['GET:/comments/2'] = comments: {id: 2, message: 'first', post_id: 1}
+      adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [2]}
+      adapter.r['GET:/comments/2'] = comments: {id: 2, message: 'first', post: 1}
 
       session.load('post', 1).then (post) ->
         expect(adapter.h).to.eql(['GET:/posts/1'])
@@ -47,10 +47,10 @@ describe "rest", ->
 
 
     it 'creates', ->
-      adapter.r['POST:/posts'] = -> posts: {client_id: post.clientId, id: 1, title: 'topological sort', comment_ids: []}
+      adapter.r['POST:/posts'] = -> posts: {client_id: post.clientId, id: 1, title: 'topological sort', comments: []}
       adapter.r['POST:/comments'] = (url, type, hash) ->
-        expect(hash.data.comment.post_id).to.eq(1)
-        return comments: {client_id: comment.clientId, id: 2, message: 'seems good', post_id: 1}
+        expect(hash.data.comment.post).to.eq(1)
+        return comments: {client_id: comment.clientId, id: 2, message: 'seems good', post: 1}
 
       post = session.create('post')
       post.title = 'topological sort'
@@ -74,7 +74,7 @@ describe "rest", ->
 
 
     it 'creates child', ->
-      adapter.r['POST:/comments'] = -> comments: {client_id: comment.clientId, id: 2, message: 'new child', post_id: 1}
+      adapter.r['POST:/comments'] = -> comments: {client_id: comment.clientId, id: 2, message: 'new child', post: 1}
 
       session.merge @Post.create(id: "1", title: 'parent');
 
@@ -105,9 +105,9 @@ describe "rest", ->
 
 
     it 'updates parent, updates child, and saves sibling', ->
-      adapter.r['PUT:/posts/1'] = -> post: {id: 1, title: 'polychild', comment_ids: [2]}
-      adapter.r['PUT:/comments/2'] = -> comments: {id: 2, title: 'original sibling', post_id: 1}
-      adapter.r['POST:/comments'] = -> comments: {client_id: sibling.clientId, id: 3, message: 'sibling', post_id: 1}
+      adapter.r['PUT:/posts/1'] = -> post: {id: 1, title: 'polychild', comments: [2]}
+      adapter.r['PUT:/comments/2'] = -> comments: {id: 2, title: 'original sibling', post: 1}
+      adapter.r['POST:/comments'] = -> comments: {client_id: sibling.clientId, id: 3, message: 'sibling', post: 1}
 
       post = @Post.create(id: "1", title: 'parent');
       post.comments.addObject(@Comment.create(id: "2", message: 'child'))
@@ -129,8 +129,8 @@ describe "rest", ->
 
 
     it 'updates with unloaded child', ->
-      adapter.r['GET:/posts/1'] = -> posts: {id: 1, title: 'mvcc ftw', comment_ids: [2]}
-      adapter.r['PUT:/posts/1'] = -> posts: {id: 1, title: 'updated', comment_ids: [2]}
+      adapter.r['GET:/posts/1'] = -> posts: {id: 1, title: 'mvcc ftw', comment: [2]}
+      adapter.r['PUT:/posts/1'] = -> posts: {id: 1, title: 'updated', comment: [2]}
       session.load('post', 1).then (post) ->
         expect(post.title).to.eq('mvcc ftw')
         expect(adapter.h).to.eql(['GET:/posts/1'])
@@ -141,7 +141,7 @@ describe "rest", ->
 
 
     it 'deletes child', ->
-      adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comment_ids: [2]}
+      adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comment: [2]}
       adapter.r['DELETE:/comments/2'] = {}
 
       post = @Post.create(id: "1", title: 'parent');
@@ -158,7 +158,7 @@ describe "rest", ->
 
 
     it 'deletes child and updates parent', ->
-      adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'childless', comment_ids: [2]}
+      adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'childless', comments: [2]}
       adapter.r['DELETE:/comments/2'] = {}
 
       post = @Post.create(id: "1", title: 'parent');
@@ -207,7 +207,7 @@ describe "rest", ->
 
 
       it 'loads', ->
-        adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, post_id: 1, message: 'first'}]}
+        adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, post: 1, message: 'first'}]}
 
         session.load(@Post, 1).then (post) ->
           expect(adapter.h).to.eql(['GET:/posts/1'])
@@ -220,8 +220,8 @@ describe "rest", ->
 
 
       it 'updates child', ->
-        adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, post_id: 1, message: 'first'}]}
-        adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, post_id: 1, message: 'first again'}]}
+        adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, post: 1, message: 'first'}]}
+        adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, post: 1, message: 'first again'}]}
 
         session.load(@Post, 1).then (post) ->
           expect(adapter.h).to.eql(['GET:/posts/1'])
@@ -235,7 +235,7 @@ describe "rest", ->
 
       it 'adds child', ->
         adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: []}
-        adapter.r['PUT:/posts/1'] =  -> posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, client_id: comment.clientId, post_id: 1, message: 'reborn'}]}
+        adapter.r['PUT:/posts/1'] =  -> posts: {id: 1, title: 'mvcc ftw', comments: [{id: 2, client_id: comment.clientId, post: 1, message: 'reborn'}]}
 
         comment = null
         session.load(@Post, 1).then (post) ->
@@ -273,7 +273,7 @@ describe "rest", ->
       it 'deletes child with sibling', ->
         adapter.r['PUT:/posts/1'] = (url, type, hash) ->
           expect(hash.data.post.comments.length).to.eq(1)
-          return posts: {id: 1, title: 'mvcc ftw', comments: [{id: 3, client_id: sibling.clientId, post_id: 1, message: 'child2'}]}
+          return posts: {id: 1, title: 'mvcc ftw', comments: [{id: 3, client_id: sibling.clientId, post: 1, message: 'child2'}]}
 
         post = @Post.create(id: "1", title: 'parent');
         post.comments.addObject(@Comment.create(id: "2", message: 'child1'))
@@ -320,7 +320,7 @@ describe "rest", ->
         # HACK: required because all knowledge of embeddedness is tracked by the adapter
         adapter._embeddedManager.updateParents(post);
 
-        adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{post_id: "1", id: "3", message: 'thing 2'}]}
+        adapter.r['PUT:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', comments: [{post: "1", id: "3", message: 'thing 2'}]}
 
         session.deleteModel post.comments.objectAt(0)
         session.flush().then ->

--- a/test/rest/rest.one_to_one.em
+++ b/test/rest/rest.one_to_one.em
@@ -34,7 +34,7 @@ describe "rest", ->
 
 
     it 'child can be null', ->
-      adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', user_id: null}
+      adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', user: null}
 
       session.load(@Post, 1).then (post) ->
         expect(post.id).to.eq("1")
@@ -43,8 +43,8 @@ describe "rest", ->
 
 
     it 'loads lazily', ->
-      adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', user_id: 2}
-      adapter.r['GET:/users/2'] = users: {id: 2, name: 'brogrammer', post_id: 1}
+      adapter.r['GET:/posts/1'] = posts: {id: 1, title: 'mvcc ftw', user: 2}
+      adapter.r['GET:/users/2'] = users: {id: 2, name: 'brogrammer', post: 1}
 
       session.load(@Post, 1).then (post) ->
         expect(adapter.h).to.eql(['GET:/posts/1'])
@@ -93,8 +93,8 @@ describe "rest", ->
 
 
     it 'creates on server', ->
-      adapter.r['POST:/posts'] = -> posts: {client_id: post.clientId, id: 1, title: 'herp', user_id: 2}
-      adapter.r['GET:/users/2'] = users: {id: 1, name: 'derp', post_id: 1}
+      adapter.r['POST:/posts'] = -> posts: {client_id: post.clientId, id: 1, title: 'herp', user: 2}
+      adapter.r['GET:/users/2'] = users: {id: 1, name: 'derp', post: 1}
 
       post = session.create 'post', title: 'herp'
 
@@ -149,7 +149,7 @@ describe "rest", ->
 
 
     it 'creates hierarchy', ->
-      adapter.r['POST:/posts'] = -> posts: {client_id: post.clientId, id: 1, title: 'herp', user: {client_id: post.user.clientId, id: 1, name: 'derp', post_id: 1}}
+      adapter.r['POST:/posts'] = -> posts: {client_id: post.clientId, id: 1, title: 'herp', user: {client_id: post.user.clientId, id: 1, name: 'derp', post: 1}}
 
       post = session.create 'post', title: 'herp'
       post.user = session.create 'user', name: 'derp'

--- a/test/rest/rest.sideloading.em
+++ b/test/rest/rest.sideloading.em
@@ -29,7 +29,7 @@ describe "rest", ->
 
 
     it 'sideloads', ->
-      adapter.r['GET:/posts/1'] = posts: {id: "1", title: 'sideload my children', comment_ids: [2, 3]}, comments: [{id: "2",  message: "here we", post_id: "1"}, {id: "3",  message: "are", post_id: "1"}]
+      adapter.r['GET:/posts/1'] = posts: {id: "1", title: 'sideload my children', comments: [2, 3]}, comments: [{id: "2",  message: "here we", post: "1"}, {id: "3",  message: "are", post: "1"}]
 
       session.load('post', 1).then (post) ->
         expect(adapter.h).to.eql(['GET:/posts/1'])

--- a/test/rest/rest_serializer.em
+++ b/test/rest/rest_serializer.em
@@ -168,14 +168,14 @@ describe 'Ep.RestSerializer', ->
 
 
     it 'deserializes null hasMany', ->
-      data = {post: [{id: 1, title: 'wat', comment_ids: null}] }
+      data = {post: [{id: 1, title: 'wat', comments: null}] }
       models = @serializer.deserializePayload(data)
       post = models[0]
       expect(post.comments.length).to.eq(0)
 
 
     it 'deserializes null belongsTo', ->
-      data = {comments: [{id: 1, title: 'wat', post_id: null}] }
+      data = {comments: [{id: 1, title: 'wat', post: null}] }
       models = @serializer.deserializePayload(data)
       comment = models[0]
       expect(comment.post).to.be.null


### PR DESCRIPTION
This PR would enhance compatibility with ember-data's conventions. If chosen not to merge (because it will break pretty much every implementation without changes to the backend), I suggest we include a clear list of EPF - ember-data discrepancies somewhere and also incorporate these in the migration guide.
