### PR TITLE
Remove store registration

### DIFF
--- a/lib/initializers.js
+++ b/lib/initializers.js
@@ -14,7 +14,6 @@ Ember.onLoad('Ember.Application', function(Application) {
       // Set the container to allow for static `find` methods on model classes
       Ep.__container__ = container;
 
-      application.register('store:main', application.Store || Ep.Store);
       application.register('adapter:main', application.Adapter || Ep.RestAdapter);
       application.register('session:base', application.Session || Ep.Session, {singleton: false});
       application.register('session:child', application.ChildSession || Ep.ChildSession, {singleton: false});


### PR DESCRIPTION
As of emberjs/ember.js@4e4ec7a66dd40e733a1e033a6e9f988097a96df6, Ember now throws an exception when attempting to register an undefined factory. This is the case with Ep.Store. Does ember require that a store be registered for some reason?
