### PR TITLE
Solves a bug in date transform (for newly created date properties)

### DIFF
--- a/lib/transforms/date.js
+++ b/lib/transforms/date.js
@@ -18,8 +18,22 @@ Ep.DateTransform = Ep.Transform.extend({
     }
   },
 
-  serialize: function(date) {
-    if (date instanceof Date) {
+  serialize: function(unserialized) {
+    var type = typeof unserialized,
+        date = null;
+
+      if (unserialized instanceof Date) {
+        date = unserialized;
+    } else if (type === 'string') {
+        date = new Date(Ember.Date.parse(unserialized));
+    } else if (type === 'number') {
+        date = new Date(unserialized);
+    }
+
+    return (date !== null) ? this._serialize(date) : null;
+  },
+
+  _serialize: function(date) {
       var days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
       var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
@@ -42,9 +56,5 @@ Ep.DateTransform = Ep.Transform.extend({
 
       return dayOfWeek + ", " + dayOfMonth + " " + month + " " + utcYear + " " +
              pad(utcHours) + ":" + pad(utcMinutes) + ":" + pad(utcSeconds) + " GMT";
-    } else {
-      return null;
-    }
-  } 
-
+  }
 });

--- a/test/rest/rest_serializer.em
+++ b/test/rest/rest_serializer.em
@@ -244,3 +244,21 @@ describe 'Ep.RestSerializer', ->
       models = @serializer.deserializePayload(data)
       post = models[0]
       expect(post.user).to.be.null
+
+
+  context 'model with date attribute', ->
+    beforeEach ->
+      @Post = Ep.Model.extend
+        posted: Ep.attr('date')
+      @container.register 'model:post', @Post, instantiate: false
+
+
+    it 'serializes', ->
+      post = @Post.create
+        id: 1
+        clientId: "2"
+        posted: "2013-05-05"
+        rev: 123
+        clientRev: 321
+      data = @serializer.serialize(post, includeId: true)
+      expect(data).to.eql(client_id: "2", id: 1, posted: 'Sun, 05 May 2013 00:00:00 GMT', rev: 123, client_rev: 321)


### PR DESCRIPTION
Previously the date transform serialize method excepted a Date object only. This resulted in a null value in the payload if a new record was saved (session.flush).

With this commit it tries to create a new Date object if a string or number are passed. Thus, serialization of newly created date properties should work now.
