### PR TITLE
Enhancements to RPC, and make server-set meta available.

### DIFF
--- a/lib/rest/operation.js
+++ b/lib/rest/operation.js
@@ -116,12 +116,17 @@ Ep.Operation = Ember.Object.extend({
         // if no data returned, assume that the server data
         // is the same as the model
         serverModel = model;
-      } else if(!get(serverModel, 'clientRev')) {
-        // ensure the clientRev is set on the returned model
-        // 0 is the default value
-        set(serverModel, 'clientRev', get(model, 'clientRev'));
+      } else {
+        if(get(serverModel, 'meta') && Ember.keys(serverModel).length == 1 ){
+          model.meta = serverModel.meta;
+          serverModel = model;
+        }
+        if(!get(serverModel, 'clientRev')) {
+          // ensure the clientRev is set on the returned model
+          // 0 is the default value
+          set(serverModel, 'clientRev', get(model, 'clientRev'));
+        }
       }
-
       return serverModel;
     }, function(serverModel) {
       // if the adapter returns errors we replace the

--- a/lib/rest/rest_adapter.js
+++ b/lib/rest/rest_adapter.js
@@ -210,7 +210,7 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
         result = model;
       }
     });
-    return result;
+    return this.setMeta(data, result);
   },
 
   didReceiveDataForLoad: function(data, type, id) {
@@ -220,7 +220,7 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
         result = model;
       }
     });
-    return result;
+    return this.setMeta(data, result);
   },
 
   didReceiveDataForFind: function(data, type) {
@@ -230,7 +230,7 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
         result.pushObject(model);
       }
     });
-    return Ep.ModelArray.create({content: result});
+    return this.setMeta(data, Ep.ModelArray.create({content: result}));
   },
 
   didReceiveDataForRpc: function(data, context) {
@@ -253,6 +253,17 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
     this.materializeRelationships(models);
   },
 
+  setMeta: function(data, obj){
+    if(data.meta){
+      if(obj){
+        obj.meta = data.meta
+      } else {
+        obj = {meta: data.meta};
+      }
+    }
+    return obj;
+  },
+  
   willLoadModel: function(model) {
     // it is possible that some models will have their clientId
     // set by the server and another (e.g. lazy) copy of the model

--- a/lib/rest/rest_adapter.js
+++ b/lib/rest/rest_adapter.js
@@ -210,7 +210,8 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
         result = model;
       }
     });
-    return this.setMeta(data, result);
+    var serializer = get(this, 'serializer');
+    return serializer.setMeta(data, result);
   },
 
   didReceiveDataForLoad: function(data, type, id) {
@@ -220,7 +221,8 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
         result = model;
       }
     });
-    return this.setMeta(data, result);
+    var serializer = get(this, 'serializer');
+    return serializer.setMeta(data, result);
   },
 
   didReceiveDataForFind: function(data, type) {
@@ -230,7 +232,8 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
         result.pushObject(model);
       }
     });
-    return this.setMeta(data, Ep.ModelArray.create({content: result}));
+    var serializer = get(this, 'serializer');
+    return serializer.setMeta(data, Ep.ModelArray.create({content: result}));
   },
 
   didReceiveDataForRpc: function(data, context) {
@@ -253,17 +256,6 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
     this.materializeRelationships(models);
   },
 
-  setMeta: function(data, obj){
-    if(data && data.meta){
-      if(obj){
-        obj.meta = data.meta
-      } else {
-        obj = {meta: data.meta};
-      }
-    }
-    return obj;
-  },
-  
   willLoadModel: function(model) {
     // it is possible that some models will have their clientId
     // set by the server and another (e.g. lazy) copy of the model

--- a/lib/rest/rest_adapter.js
+++ b/lib/rest/rest_adapter.js
@@ -258,7 +258,7 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
   },
 
   setMeta: function(data, obj){
-    if(data.meta){
+    if(data && data.meta){
       if(obj){
         obj.meta = data.meta
       } else {

--- a/lib/rest/rest_adapter.js
+++ b/lib/rest/rest_adapter.js
@@ -170,7 +170,7 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
     });
   },
 
-  remoteCall: function(context, name, params) {
+  remoteCall: function(context, name, params, method) {
     var url, adapter = this;
     if(typeof context === "string") {
       context = this.typeFor(context);
@@ -185,12 +185,8 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
 
     url = url + '/' + name;
 
-    var method = "POST";
-    if(params && get(params, '_method')){
-      method = get(params, '_method');
-      delete params._method;
-    }
-    
+    method = method || "POST";
+
     // TODO: serialize models passed in the params
     var data = params;
 

--- a/lib/rest/rest_adapter.js
+++ b/lib/rest/rest_adapter.js
@@ -234,7 +234,11 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
   },
 
   didReceiveDataForRpc: function(data, context) {
-    return this.didReceiveData(data, context);
+    if(typeof context === 'function') {
+      return this.didReceiveDataForFind(data, context);
+    } else {
+      return this.didReceiveData(data, context);      
+    }
   },
 
   processData: function(data, callback, binding) {

--- a/lib/rest/rest_adapter.js
+++ b/lib/rest/rest_adapter.js
@@ -185,11 +185,15 @@ Ep.RestAdapter = Ep.Adapter.extend(Ep.EmbeddedHelpersMixin, {
 
     url = url + '/' + name;
 
+    var method = "POST";
+    if(params && get(params, '_method')){
+      method = get(params, '_method');
+      delete params._method;
+    }
+    
     // TODO: serialize models passed in the params
     var data = params;
 
-    // TODO: how to specify method?
-    var method = "POST";
     return this.ajax(url, method,{
       data: data
     }).then(function(json){

--- a/lib/rest/rest_serializer.js
+++ b/lib/rest/rest_serializer.js
@@ -85,7 +85,20 @@ Ep.RestSerializer = Ep.JsonSerializer.extend({
         errors[name] = json['errors'][key];
       }
     }, this);
-
+    if(json['errors'].hasOwnProperty('base')){
+      errors['base'] = json['errors']['base'];      
+    }
     return errors;
-  }
+  },
+  
+  setMeta: function(data, obj){
+    if(data && data.meta){
+      if(obj){
+        obj.meta = data.meta
+      } else {
+        obj = {meta: data.meta};
+      }
+    }
+    return obj;
+  }  
 });

--- a/lib/session/child_session.js
+++ b/lib/session/child_session.js
@@ -57,12 +57,7 @@ Ep.ChildSession = Ep.Session.extend({
     var session = this;
     return this.parent.query(type, query).then(function(models) {
       // TODO: model array could automatically add to session?
-      var merged = Ep.ModelArray.create({session: session, content: []});
-      set(merged, 'meta', get(models, 'meta'));
-      models.forEach(function(model) {
-        merged.pushObject(session.merge(model));
-      });
-      return merged;
+      return session.mergeModels(models);
     });
   },
 
@@ -125,9 +120,17 @@ Ep.ChildSession = Ep.Session.extend({
   remoteCall: function(context, name) {
     var session = this;
     return this.parent.remoteCall.apply(this.parent, arguments).then(function(model) {
-      return session.merge(model);
+      if(Ember.isArray(model)) {
+        return session.mergeModels(models);
+      } else {
+        return session.merge(model);
+      }
     }, function(model) {
-      throw session.merge(model);
+      if(Ember.isArray(model)) {
+        throw session.mergeModels(models);
+      }else{
+        throw session.merge(model);
+      }
     });
   }
 

--- a/lib/session/child_session.js
+++ b/lib/session/child_session.js
@@ -117,7 +117,7 @@ Ep.ChildSession = Ep.Session.extend({
     return this.models.getForClientId(clientId);
   },
 
-  remoteCall: function(context, name, params) {
+  remoteCall: function(context, name, params, method) {
     var session = this;
     return this.parent.remoteCall.apply(this.parent, arguments).then(function(model) {
       if(Ember.isArray(model)) {

--- a/lib/session/child_session.js
+++ b/lib/session/child_session.js
@@ -117,7 +117,7 @@ Ep.ChildSession = Ep.Session.extend({
     return this.models.getForClientId(clientId);
   },
 
-  remoteCall: function(context, name) {
+  remoteCall: function(context, name, params) {
     var session = this;
     return this.parent.remoteCall.apply(this.parent, arguments).then(function(model) {
       if(Ember.isArray(model)) {

--- a/lib/session/merge.js
+++ b/lib/session/merge.js
@@ -53,6 +53,16 @@ Ep.Session.reopen({
     return merged;
   },
 
+  mergeModels: function(models) {
+    var merged = Ep.ModelArray.create({session: this, content: []});
+    set(merged, 'meta', get(models, 'meta'));
+    var session = this;
+    models.forEach(function(model) {
+      merged.pushObject(session.merge(model));
+    });
+    return merged;
+  },
+
   _mergeSuccess: function(model, strategy) {
     var models = get(this, 'models'),
         shadows = get(this, 'shadows'),

--- a/lib/session/merge.js
+++ b/lib/session/merge.js
@@ -45,6 +45,10 @@ Ep.Session.reopen({
       merged = this._mergeSuccess(model, strategy);
     }
 
+    if(model.meta){
+      merged.meta = model.meta;
+    }
+    
     for(var i = 0; i < detachedChildren.length; i++) {
       var child = detachedChildren[i];
       this.merge(child, strategy, visited);
@@ -55,7 +59,7 @@ Ep.Session.reopen({
 
   mergeModels: function(models) {
     var merged = Ep.ModelArray.create({session: this, content: []});
-    set(merged, 'meta', get(models, 'meta'));
+    merged.meta = models.meta;
     var session = this;
     models.forEach(function(model) {
       merged.pushObject(session.merge(model));

--- a/lib/session/session.js
+++ b/lib/session/session.js
@@ -307,7 +307,7 @@ Ep.Session = Ember.Object.extend({
     this.adapter.reifyClientId(model);
   },
 
-  remoteCall: function(context, name, params) {
+  remoteCall: function(context, name, params, method) {
     var session = this;
     return this.adapter.remoteCall.apply(this.adapter, arguments).then(function(model) {
       if(Ember.isArray(model)) {

--- a/lib/session/session.js
+++ b/lib/session/session.js
@@ -232,12 +232,7 @@ Ep.Session = Ember.Object.extend({
     // TODO: return a model array immediately here
     // and also take into account errors
     var prom = this.adapter.query(type, query).then(function(models) {
-      var merged = Ep.ModelArray.create({session: session, content: []});
-      set(merged, 'meta', get(models, 'meta'));
-      models.forEach(function(model) {
-        merged.pushObject(session.merge(model));
-      });
-      return merged;
+      return session.mergeModels(models);
     });
     return Ep.PromiseArray.create({promise:prom});
   },
@@ -315,9 +310,17 @@ Ep.Session = Ember.Object.extend({
   remoteCall: function(context, name) {
     var session = this;
     return this.adapter.remoteCall.apply(this.adapter, arguments).then(function(model) {
-      return session.merge(model);
+      if(Ember.isArray(model)) {
+        return session.mergeModels(model);
+      } else {
+        return session.merge(model);        
+      }
     }, function(model) {
-      throw session.merge(model);
+      if(Ember.isArray(model)) {
+        throw session.mergeModels(model);
+      }else{
+        throw session.merge(model);        
+      }
     });
   },
 

--- a/lib/session/session.js
+++ b/lib/session/session.js
@@ -307,7 +307,7 @@ Ep.Session = Ember.Object.extend({
     this.adapter.reifyClientId(model);
   },
 
-  remoteCall: function(context, name) {
+  remoteCall: function(context, name, params) {
     var session = this;
     return this.adapter.remoteCall.apply(this.adapter, arguments).then(function(model) {
       if(Ember.isArray(model)) {

--- a/test/rest/rest.meta.em
+++ b/test/rest/rest.meta.em
@@ -1,0 +1,134 @@
+describe "rest", ->
+
+  adapter = null
+  session = null
+
+  beforeEach ->
+    require('./_shared').setupRest.apply(this)
+    adapter = @adapter
+    session = @session
+
+  context 'returns meta data when', ->
+
+    beforeEach ->
+      class @Post extends Ep.Model
+        title: Ep.attr('string')
+      @App.Post = @Post
+
+      @container.register 'model:post', @Post, instantiate: false
+
+
+    it 'loads', ->
+      adapter.r['GET:/posts/1'] = meta: {traffic: 'heavy'}, posts: {id: 1, title: 'mvcc ftw'}
+      session.load(@Post, 1).then (post) ->
+        expect(post.meta.traffic).to.eq('heavy')
+        expect(post.id).to.eq("1")
+        expect(post.title).to.eq('mvcc ftw')
+        expect(adapter.h).to.eql(['GET:/posts/1'])
+
+
+    it 'saves', ->
+      adapter.r['POST:/posts'] = -> meta: {traffic: 'heavy'}, posts: {client_id: post.clientId, id: 1, title: 'mvcc ftw'}
+
+      post = session.create('post')
+      post.title = 'mvcc ftw'
+
+      session.flush().then (result)->
+        expect(result.firstObject.meta.traffic).to.eq('heavy')
+        expect(post.id).to.eq("1")
+        expect(post.title).to.eq('mvcc ftw')
+        expect(adapter.h).to.eql(['POST:/posts'])
+
+
+    it 'updates', ->
+      adapter.r['PUT:/posts/1'] = -> meta: {traffic: 'heavy'}, posts: {id: 1, title: 'updated'}
+
+      session.merge @Post.create(id: "1", title: 'test')
+
+      session.load('post', 1).then (post) ->
+        expect(post.title).to.eq('test')
+        post.title = 'updated'
+        session.flush().then (result)->
+          expect(result.firstObject.meta.traffic).to.eq('heavy')
+          expect(post.title).to.eq('updated')
+          expect(adapter.h).to.eql(['PUT:/posts/1'])
+
+
+    it 'updates multiple times', ->
+      adapter.r['PUT:/posts/1'] = -> meta: {traffic: 'heavy'}, posts: {id: 1, title: 'updated'}
+
+      post = session.merge @Post.create(id: "1", title: 'test')
+
+      expect(post.title).to.eq('test')
+      post.title = 'updated'
+
+      session.flush().then  (result)->
+        expect(result.firstObject.meta.traffic).to.eq('heavy')
+        expect(post.title).to.eq('updated')
+        expect(adapter.h).to.eql(['PUT:/posts/1'])
+
+        adapter.r['PUT:/posts/1'] = -> meta: {traffic: 'lighter'}, posts: {id: 1, title: 'updated again'}
+        post.title = 'updated again'
+        session.flush().then (result)->
+          expect(result.firstObject.meta.traffic).to.eq('lighter')
+          expect(post.title).to.eq('updated again')
+          expect(adapter.h).to.eql(['PUT:/posts/1', 'PUT:/posts/1'])
+
+
+    it 'deletes', ->
+      adapter.r['DELETE:/posts/1'] = meta: {traffic: 'heavy'}
+
+      session.merge @Post.create(id: "1", title: 'test')
+
+      session.load('post', 1).then (post) ->
+        expect(post.id).to.eq("1")
+        expect(post.title).to.eq('test')
+        session.deleteModel(post)
+        session.flush().then (result)->
+          expect(result.firstObject.meta.traffic).to.eq('heavy')
+          expect(post.isDeleted).to.be.true
+          expect(adapter.h).to.eql(['DELETE:/posts/1'])
+
+
+    it 'refreshes', ->
+      adapter.r['GET:/posts/1'] = meta: {traffic: 'lighter'}, posts: {id: 1, title: 'something new'}
+
+      session.merge @Post.create(id: "1", title: 'test')
+
+      session.load(@Post, 1).then (post) ->
+        expect(post.title).to.eq('test')
+        expect(adapter.h).to.eql([])
+        session.refresh(post).then (post) ->
+          expect(post.title).to.eq('something new')
+          expect(post.meta.traffic).to.eq('lighter')
+          expect(adapter.h).to.eql(['GET:/posts/1'])
+
+
+    it 'finds', ->
+      adapter.r['GET:/posts'] = (url, type, hash) ->
+        expect(hash.data).to.eql({q: "aardvarks"})
+        meta: {traffic: 'heavy'}, posts: [{id: 1, title: 'aardvarks explained'}, {id: 2, title: 'aardvarks in depth'}]
+
+      session.find('post', {q: 'aardvarks'}).then (models) ->
+        expect(models.meta.traffic).to.eq('heavy')
+        expect(models.length).to.eq(2)
+        expect(adapter.h).to.eql(['GET:/posts'])
+
+
+    it 'loads then updates in a child session', ->
+      adapter.r['GET:/posts/1'] = meta: {traffic: 'heavy'}, posts: {id: 1, title: 'mvcc ftw'}
+      adapter.r['PUT:/posts/1'] = meta: {traffic: 'lighter'}, posts: {id: 1, title: 'no more fsm'}
+
+      childSession = session.newSession()
+      childSession.load(@Post, 1).then (post) ->
+        expect(post.id).to.eq("1")
+        expect(post.title).to.eq('mvcc ftw')
+        expect(post.meta.traffic).to.eq('heavy')
+        expect(adapter.h).to.eql(['GET:/posts/1'])
+
+        post.title = 'no more fsm'
+        childSession.flush().then (result)->
+          expect(result.firstObject.meta.traffic).to.eq('lighter')
+          expect(adapter.h).to.eql(['GET:/posts/1', 'PUT:/posts/1'])
+          expect(post.title).to.eq('no more fsm')
+  

--- a/test/rest/rest.rpc.em
+++ b/test/rest/rest.rpc.em
@@ -30,6 +30,17 @@ describe "rest", ->
           expect(post.title).to.eq('submitted')
           expect(post.submitted).to.be.true
 
+    it 'handles remote calls on the collection', ->
+      adapter.r['POST:/posts/randomize'] = ->
+        posts: [{id: 1, title: 'submitted', submitted: true}, {id: 2, title: 'submitted2', submitted: true}]
+
+      session.remoteCall('post', 'randomize').then (models) ->
+          expect(models.length).to.eq(2)
+          expect(models.firstObject.title).to.eq('submitted')
+          expect(models.firstObject.submitted).to.be.true
+          expect(adapter.h).to.eql(['POST:/posts/randomize'])
+
+
 
     # it.only 'works with model name as context', ->
     #   adapter.r['POST:/posts/import'] = ->

--- a/test/rest/rest.rpc.em
+++ b/test/rest/rest.rpc.em
@@ -62,3 +62,17 @@ describe "rest", ->
           expect(adapter.h).to.eql(['POST:/posts/1/submit'])
           expect(post.title).to.eq('submitted')
           expect(post.submitted).to.be.true
+
+    it 'passes through metadata', ->
+      adapter.r['POST:/posts/1/submit'] = ->
+        meta: {traffic: 'heavy'}, posts: {id: 1, title: 'submitted', submitted: "true"}
+
+      session.merge @Post.create(id: "1", title: 'test', submitted: false)
+
+      session.load('post', 1).then (post) ->
+        session.remoteCall(post, 'submit', token: 'asd').then ->
+          expect(adapter.h).to.eql(['POST:/posts/1/submit'])
+          expect(post.meta.traffic).to.eq('heavy')
+          expect(post.title).to.eq('submitted')
+          expect(post.submitted).to.be.true
+   

--- a/test/rest/rest.rpc.em
+++ b/test/rest/rest.rpc.em
@@ -75,4 +75,15 @@ describe "rest", ->
           expect(post.meta.traffic).to.eq('heavy')
           expect(post.title).to.eq('submitted')
           expect(post.submitted).to.be.true
-   
+
+    it 'can accept a method', ->
+      adapter.r['PUT:/posts/1/submit'] = ->
+        posts: {id: 1, title: 'submitted', submitted: "true"}
+
+      session.merge @Post.create(id: "1", title: 'test', submitted: false)
+
+      session.load('post', 1).then (post) ->
+        session.remoteCall(post, 'submit', {token: 'asd', _method: 'PUT'}).then ->
+          expect(adapter.h).to.eql(['PUT:/posts/1/submit'])
+          expect(post.title).to.eq('submitted')
+          expect(post.submitted).to.be.true

--- a/test/rest/rest.rpc.em
+++ b/test/rest/rest.rpc.em
@@ -83,7 +83,7 @@ describe "rest", ->
       session.merge @Post.create(id: "1", title: 'test', submitted: false)
 
       session.load('post', 1).then (post) ->
-        session.remoteCall(post, 'submit', {token: 'asd', _method: 'PUT'}).then ->
+        session.remoteCall(post, 'submit', {token: 'asd'}, 'PUT').then ->
           expect(adapter.h).to.eql(['PUT:/posts/1/submit'])
           expect(post.title).to.eq('submitted')
           expect(post.submitted).to.be.true

--- a/test/rest/rest_serializer.em
+++ b/test/rest/rest_serializer.em
@@ -244,3 +244,23 @@ describe 'Ep.RestSerializer', ->
       models = @serializer.deserializePayload(data)
       post = models[0]
       expect(post.user).to.be.null
+      
+      
+  describe 'meta data', ->
+    it 'adds meta data to existing object', ->
+      obj = {title: 'wat'}
+      data = {meta: {recursive: 'meta'}}
+      obj = @serializer.setMeta(data, obj)
+      expect(obj.meta).to.exist
+      expect(obj.meta.recursive).to.exist
+      expect(obj.meta.recursive).to.eq('meta')
+      
+    it 'adds creates an object with meta if object undefined', ->
+      data = {meta: {recursive: 'meta'}}
+      obj = @serializer.setMeta(data, obj)
+      expect(obj.meta).to.exist
+      expect(obj.meta.recursive).to.exist
+      expect(obj.meta.recursive).to.eq('meta')
+      
+    
+  


### PR DESCRIPTION
1. allow RPC calls against the collection (ie, matching the following import route in a rails api):
   
   ```
   resources :widget do
     collection do
       post 'import' => :import
     end
   end
   ```
2. Make meta property set on the server always available. The implementation is somewhat ugly, but the result is that whatever you do that hits the server, the meta info will be available in the `then` of the promise. In the case of a flush, each of the models in the result set passed to the `then` of the flush will have the `meta` that was set by its (last) operation. In the case of a query, the `meta` will be set on the model array. It is set as bare javascript property, not as an ember property. Should I change this?
3. Allow choosing an HTTP method for RPC (by setting `_method` in params)

My original needs involved all three of these things, but I think they are orthogonal, and if you want I can make separate branches & pull requests for them.
