### PR TITLE
serializerFor should only override typeKey if it doesn't already exist

### DIFF
--- a/lib/serializers/serializer_for_mixin.js
+++ b/lib/serializers/serializer_for_mixin.js
@@ -15,7 +15,11 @@ module.exports = Ember.Mixin.create({
       this.container.register('serializer:' + lookupKey, Serializer);
       serializer = this.container.lookup('serializer:' + lookupKey);
     }
-    serializer.typeKey = typeKey;
+
+    if (!serializer.typeKey) {
+      serializer.typeKey = typeKey;
+    }
+
     return serializer;
   },
 

--- a/test/rest/rest.serialization.em
+++ b/test/rest/rest.serialization.em
@@ -12,6 +12,17 @@ describe 'rest serialization', ->
         longTitle: Ep.attr('string')
       @container.register 'model:post', @Post
 
+    describe "overriding a serializer's typeKey", ->
+
+      it 'returns a model of that type', ->
+        SpecialPostSerializer = Ep.ModelSerializer.extend
+          typeKey: 'post'
+
+        @container.register 'serializer:special-post', SpecialPostSerializer
+        data = {special_posts: [{id: 1, title: 'wat', user: null}] }
+        models = @serializer.deserialize(data)
+        post = models[0]
+        expect(post).to.be.an.instanceof(@Post)
 
     describe 'deserialize', ->
 


### PR DESCRIPTION
I have multiple ways of serializing data because of a legacy API server:

``` js
Address = Ep.Model.extend({
  street: Ep.attr('string'),
  city: Ep.attr('string'),
  state: Ep.attr('string')
});

// Legacy API server ships JSON like:
{ matched_addresses: [ {uglyStreet: '...', oldCity: '...', funkyState: '...'} ] };

// Shiny new API server ships what you'd expect:
{ addresses: [ {street: '...', city: '...', state: '...'} ] };
```

I'd like both `matched_addresses` and `addresses` to deserialize to an `Address` instance. To do this, I could create a custom serializer:

``` js
MatchedAddressSerializer = Ep.ModelSerializer.extend({
  // Without my PR, this gets overwritten in `serializerFor`
  typeKey: 'address',

  deserialize: function(json) {
    return this._super({
      street: json.uglyStreet,
      city: json.oldCity,
      state: json.funkyState
    });
  }
});
```

Right now, this isn't possible because `serializerFor` overwrites `typeKey`. I just added a check.
